### PR TITLE
add more question and fix losing data when screen is rotated

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
         android:roundIcon="@mipmap/ic_fire_icon_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.CrossFire">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity" android:configChanges="orientation|screenSize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
         android:roundIcon="@mipmap/ic_fire_icon_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.CrossFire">
-        <activity android:name=".MainActivity" android:configChanges="orientation|screenSize">
+        <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/krsolutions/crossFire/Question.kt
+++ b/app/src/main/java/com/krsolutions/crossFire/Question.kt
@@ -17,6 +17,11 @@ object QuestionsBank {
             "Coffee is consumed by about one-third of Earth's population."
         ),
         Question(
+          "Candi Sewu in Indonesia only made in 1 night.",
+            isTrue = true,
+            "There's a legend about Candi Sewu where the all of the candi (sewu means 1000) only made in 1 night because of love."
+        ),
+        Question(
             "Approximately one quarter of human bones are in the feet",
             true,
             "True – 52 bones in the feet and 206 in the whole body."

--- a/app/src/main/java/com/krsolutions/crossFire/QuestionActivity.kt
+++ b/app/src/main/java/com/krsolutions/crossFire/QuestionActivity.kt
@@ -5,6 +5,8 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.os.PersistableBundle
+import android.util.Log
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import com.krsolutions.crossFire.databinding.ActivityQuestionBinding
@@ -21,6 +23,7 @@ class QuestionActivity : AppCompatActivity() {
         binding = ActivityQuestionBinding.inflate(layoutInflater)
         val view = binding.root
         setContentView(view)
+
         binding.trueOption.setOnClickListener(onAnsClickListener)
         binding.falseOption.setOnClickListener(onAnsClickListener)
         binding.question.text = questionsBank[questionNum].question
@@ -112,5 +115,28 @@ class QuestionActivity : AppCompatActivity() {
                 finish()
             }
         }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+
+        val saveQuestionNum = questionNum
+        val saveCorrectCounter = correctCounter
+
+        outState.putInt("saveQuestionNum", saveQuestionNum)
+        outState.putInt("saveCorrectCounter", saveCorrectCounter)
+        Log.d("Saved Number ", saveQuestionNum.toString())
+    }
+
+    override fun onRestoreInstanceState(savedInstanceState: Bundle) {
+        super.onRestoreInstanceState(savedInstanceState)
+
+        val savedQuestionNum = savedInstanceState.getInt("saveQuestionNum")
+        questionNum = savedQuestionNum
+
+        val savedCorrectCounter = savedInstanceState.getInt("saveCorrectCounter")
+        correctCounter = savedCorrectCounter
+
+        binding.counter.text ="${questionNum+1}/${questionsBank.size}"
     }
 }

--- a/app/src/main/java/com/krsolutions/crossFire/QuestionActivity.kt
+++ b/app/src/main/java/com/krsolutions/crossFire/QuestionActivity.kt
@@ -5,8 +5,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
-import android.os.PersistableBundle
-import android.util.Log
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import com.krsolutions.crossFire.databinding.ActivityQuestionBinding
@@ -125,7 +123,6 @@ class QuestionActivity : AppCompatActivity() {
 
         outState.putInt("saveQuestionNum", saveQuestionNum)
         outState.putInt("saveCorrectCounter", saveCorrectCounter)
-        Log.d("Saved Number ", saveQuestionNum.toString())
     }
 
     override fun onRestoreInstanceState(savedInstanceState: Bundle) {


### PR DESCRIPTION
Hey, I added more question and I see there are issues losing the data when orientation. I fix it where now it can save the `questionNum` and `correctCounter` data. But the `questionBank` still randomize means the question will change every time screen is rotated.